### PR TITLE
audio finish

### DIFF
--- a/Allright/Page/Component/HomeStepCard.swift
+++ b/Allright/Page/Component/HomeStepCard.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct HomeStepCard: View {
     let step: TrainingSteps
+    @Binding var selection: Int
     
     var body: some View {
         RoundedRectangle(cornerRadius: 20)
@@ -49,9 +50,9 @@ struct HomeStepCard: View {
                 Spacer()
                 NavigationLink {
                     switch step {
-                    case .step1: ReadView(step: step)
-                    case .step2: ReadView(step: step)
-                    case .sentance: ReadView(step: step)
+                    case .step1: ReadView(step: step, selection: $selection)
+                    case .step2: ReadView(step: step, selection: $selection)
+                    case .sentance: ReadView(step: step, selection: $selection)
                     }
                 } label: {
                     RoundedRectangle(cornerRadius: 1000)
@@ -77,9 +78,3 @@ struct HomeStepCard: View {
 
 }
 
-
-struct HomeStepCardView_Preview: PreviewProvider {
-    static var previews: some View {
-        HomeStepCard(step: .sentance)
-    }
-}

--- a/Allright/Page/Home/HomeView.swift
+++ b/Allright/Page/Home/HomeView.swift
@@ -9,19 +9,18 @@ import SwiftUI
 
 struct HomeView: View {
     @StateObject private var homeVM = HomeVM()
+    @Binding var selection: Int
     
     var body: some View {
-        NavigationStack {
             VStack(spacing: UIScreen.getHeight(16)) {
                 topBanner
                 Spacer()
-                HomeStepCard(step: .step1)
-                HomeStepCard(step: .step2)
-                HomeStepCard(step: .sentance)
+                HomeStepCard(step: .step1, selection: $selection)
+                HomeStepCard(step: .step2, selection: $selection)
+                HomeStepCard(step: .sentance, selection: $selection)
                 Spacer()
                 Spacer().frame(height: UITabBarController().height)
             }
-        }
     }
 //MARK: - UI
     var topBanner: some View {
@@ -44,10 +43,4 @@ struct HomeView: View {
     }
     
     
-}
-
-struct HomeView_Preview: PreviewProvider {
-    static var previews: some View {
-        HomeView()
-    }
 }

--- a/Allright/Page/Main/MainView.swift
+++ b/Allright/Page/Main/MainView.swift
@@ -8,20 +8,24 @@
 import SwiftUI
 
 struct MainView: View {
+    @State private(set) var selection = 0
+    
     var body: some View {
-        ZStack {
-            TabView {
-                HomeView()
-                    .tag(0)
-                    .tabItem {
-                        Text("home")
-                    }
-                RecordView()
-                    .tag(1)
-                    .tabItem {
-                        Text("record")
-                    }
-            }
+        NavigationStack {
+            ZStack {
+                TabView(selection: $selection) {
+                    HomeView(selection: $selection)
+                        .tag(0)
+                        .tabItem {
+                            Text("home")
+                        }
+                    RecordView()
+                        .tag(1)
+                        .tabItem {
+                            Text("record")
+                        }
+                }
+            }            
         }
     }
 }

--- a/Allright/Page/Read/ReadVM.swift
+++ b/Allright/Page/Read/ReadVM.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 
 class ReadVM: ObservableObject {
+
+    var step: TrainingSteps?
     @Published var isSoundOn = false
     @Published var numberOfWords: Int = 0
     @Published var currentIndex: Int = 0
@@ -16,7 +18,10 @@ class ReadVM: ObservableObject {
     @Published var startCountDown = 3
     @Published var isPlaying = false
     @Published var timer: Timer?
+    @Published var isFinished = false
+    @Published var isPaused = false
     
+    let recoder = VoicerecordVM()
     
     // 현재 stop 됐을때, numberofwords != currentIdx면, 알람창을띄워줌, 현재 녹음중인데 중단하시겠어요?, 취소면 재계 아니면 화면 나감.
     // NOW가 currentIdx면 녹음이 완료 되었습니다. 상태창 띄워주기
@@ -29,6 +34,12 @@ class ReadVM: ObservableObject {
         }
     }
     
+    func resetReadVM() {
+        currentIndex = 0
+        startCountDown = 3
+        stopAnimation()
+    }
+    
     func startAnimation() {
         isPlaying = true
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
@@ -36,9 +47,20 @@ class ReadVM: ObservableObject {
                 self.startCountDown -= 1
             }
             else if self.startCountDown == 0, self.isPlaying, (self.currentIndex != self.numberOfWords - 1) {
+                guard let step = self.step else { return }
+                if self.currentIndex == 1 {
+                    self.recoder.startRecording(typeIs: step.type)
+                }
+                else {
+                    self.isPaused = false
+                    self.recoder.resumeRecording()
+                }
                 withAnimation(.linear(duration: 0.4)) {
                     self.currentIndex += 1
                 }
+            }
+            else {
+                self.stopAnimation()
             }
         }
     }
@@ -46,5 +68,13 @@ class ReadVM: ObservableObject {
     func stopAnimation() {
         isPlaying = false
         timer!.invalidate()
+        if self.currentIndex == numberOfWords - 1 {
+            isFinished  = true
+            recoder.stopRecording()
+        }
+        else if self.currentIndex >= 1, currentIndex != numberOfWords - 1 {
+            isPaused = true
+            recoder.pauseRecording()
+        }
     }
 }

--- a/Allright/Page/Read/ReadView.swift
+++ b/Allright/Page/Read/ReadView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct ReadView: View {
     let step: TrainingSteps
+    @Binding var selection: Int
     @StateObject private var readVM = ReadVM()
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
@@ -42,8 +43,32 @@ struct ReadView: View {
                 Spacer().frame(height: UITabBarController().height)
             }
         }
+        .alert("연습이 완료되었어요!", isPresented: $readVM.isFinished, actions: {
+            Button("녹음듣기", role: .none) {
+                readVM.resetReadVM()
+                selection = 1
+                self.presentationMode.wrappedValue.dismiss()
+            }
+            Button("완료", role: .cancel) {
+                readVM.resetReadVM()
+            }
+        }, message: {
+            Text("녹음기록을 바로 들어볼까요?")
+        })
+        .alert("연습을 중단할까요?", isPresented: $readVM.isPaused, actions: {
+            Button("취소", role: .none) {
+                readVM.isPlaying = true
+                readVM.startAnimation()
+            }
+            Button("중단하기", role: .cancel) {
+                readVM.resetReadVM()
+            }
+        }, message: {
+            Text("현재까지의 녹음 기록은 저장돼요")
+        })
         .onAppear {
             readVM.numberOfWords = step.wordCard.count
+            readVM.step = step
         }
         .navigationTitle(step.title)
         .navigationBarBackButtonHidden(true)
@@ -192,9 +217,3 @@ struct ReadView: View {
     }
 }
 
-
-struct RowView_Preview: PreviewProvider {
-    static var previews: some View {
-        ReadView(step: .step2)
-    }
-}

--- a/Allright/Page/VoicerecordVM.swift
+++ b/Allright/Page/VoicerecordVM.swift
@@ -9,7 +9,7 @@ import Foundation
 import AVFoundation
 
 class VoicerecordVM: NSObject, ObservableObject, AVAudioPlayerDelegate {
-    var audioRecorder: AVAudioRecorder!
+    var audioRecorder = AVAudioRecorder()
     var audioPlayer: AVAudioPlayer!
     
     @Published var isRecording: Bool = false
@@ -19,7 +19,6 @@ class VoicerecordVM: NSObject, ObservableObject, AVAudioPlayerDelegate {
     
     override init() {
         super.init()
-        
         fetchVoicerecordFile()
     }
     
@@ -110,10 +109,19 @@ class VoicerecordVM: NSObject, ObservableObject, AVAudioPlayerDelegate {
         }
     }
     
+    func pauseRecording() {
+        audioRecorder.pause()
+        isRecording = false
+    }
+    
+    func resumeRecording() {
+        audioRecorder.record()
+        isRecording = true
+    }
+    
     func stopRecording() {
         audioRecorder.stop()
         isRecording = false
-        
         fetchVoicerecordFile()
     }
     


### PR DESCRIPTION
# 한일
## 오디오 정지 후 재생 관련 메소드 추가
<img width="545" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/96717313/11f98056-8a65-4573-bf4a-ee84be157da5">
<img width="444" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/96717313/a5b908e2-ab01-4a77-9d34-79cd854467dd">

이렇게 위에 audiorecorder를 생성해주는것으로 계속해서 발생했던 nil 이 들어오는것을 막아줬습니다. 

## 뷰 안에서 tabview가 보이는 문제
<img width="634" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/96717313/878c27b0-aeab-4001-a1ef-352fa8df95d4">

navigationstack으로 tabview를 감싸주는것으로 상위 컨트롤러 처리를 해줌으로 navigation을 타고 들어갈때 tabview가 보이지 않도록 하였습니다. 

## 애니메이션 시작 하는 로직
<img width="70%" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/96717313/65900551-afa5-49b2-8981-d00d00f992f9">

애니메이션이 시작하는 부분의 분기처리를 통하여 메소드가 잘 실행되도록 하였습니다. 
하지만 해당 부분에 강한참조가 너무 많아보여서 이부분의 개선이 필요할것 같습니다. 
