### PR TITLE
feat: 녹음이 종료되었을 때 audio session 전환

### DIFF
--- a/Allright/Page/VoicePlayer.swift
+++ b/Allright/Page/VoicePlayer.swift
@@ -27,6 +27,7 @@ class VoicePlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
         
         do {
             try playSession.setCategory(.playAndRecord, mode: .default, options: [.allowBluetooth, .allowBluetoothA2DP])
+            try playSession.overrideOutputAudioPort(.none)
             try playSession.setActive(true)
             
         } catch {

--- a/Allright/Page/VoiceRecorder.swift
+++ b/Allright/Page/VoiceRecorder.swift
@@ -118,6 +118,7 @@ class VoiceRecorder: NSObject, ObservableObject {
     
     func stopRecording() {
         audioRecorder.stop()
+        VoicePlayer.setSession()
         isRecording = false
         fetchVoicerecordFile()
     }


### PR DESCRIPTION
## session 함수 수정
```swift
static func setSession() {
        let playSession = AVAudioSession.sharedInstance()
        
        do {
            try playSession.setCategory(.playAndRecord, mode: .default, options: [.allowBluetooth, .allowBluetoothA2DP])
            try playSession.overrideOutputAudioPort(.none)
            try playSession.setActive(true)
            
        } catch {
            print("Playing failed in Device")
        }
    }
``` 

```swift
try playSession.overrideOutputAudioPort(.none)
// 디폴트 오디오 출력이 스피커로 전환되는 거 해제
``` 

## 녹음 종료 시 세션 재설정
```swift
    func stopRecording() {
        audioRecorder.stop()
        VoicePlayer.setSession()
        isRecording = false
        fetchVoicerecordFile()
    }
``` 