### PR TITLE
feat: 로띠, 플레이 버튼 코드 그룹화

### DIFF
--- a/Allright/Page/Read/ReadView.swift
+++ b/Allright/Page/Read/ReadView.swift
@@ -49,12 +49,11 @@ struct ReadView: View {
             }
             VStack {
                 Spacer()
-                LottieView(isPlay: $readVM.isPlaying)
-                    .frame(width: UIScreen.getWidth(200), height: UIScreen.getHeight(200))
-            }
-            VStack {
-                Spacer()
-                playButton
+                ZStack {
+                    LottieView(isPlay: $readVM.isPlaying)
+                    playButton
+                }
+                .frame(width: UIScreen.getWidth(200), height: UIScreen.getHeight(200))
                 Spacer().frame(height: UITabBarController().height)
             }
         }


### PR DESCRIPTION
## 로띠 뷰, 플레이 버튼 불일치
se 모델을 비롯해 pro max 모델 또한 로띠와 플레이 버튼이 동일한 위치에 존재하지 않는 현상

<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/97587585/549e4deb-73ee-442c-a356-33bea4ba7890" width="250" height="400"/>
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/97587585/c1174014-47b2-4cd6-9e52-dded01e281c0" width="250" height="400"/>
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/97587585/1a61b2b1-a450-4ae7-b6b3-1b85921a70bb.png" width="250" height="400"/>

<- 전, 후 ->

 <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/97587585/fd172e1c-bc13-415b-a615-a8b5a5246b4f" width="250" height="400"/>
 <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Allright/assets/97587585/f132ceee-5eef-4c3c-9ca3-d2f799f9fd1a" width="250" height="400"/>

## 코드
로띠 뷰와 플레이 버튼을 그룹핑했습니다.

```swift
            VStack {
                Spacer()
                LottieView(isPlay: $readVM.isPlaying)
                    .frame(width: UIScreen.getWidth(200), height: UIScreen.getHeight(200))
            }
            VStack {
                Spacer()
                playButton
                Spacer().frame(height: UITabBarController().height)
            }
``` 
<- 전, 후 ->
```swift
            VStack {
                Spacer()
                ZStack {
                    LottieView(isPlay: $readVM.isPlaying)
                    playButton
                }
                .frame(width: UIScreen.getWidth(200), height: UIScreen.getHeight(200))
                Spacer().frame(height: UITabBarController().height)
            }
``` 
